### PR TITLE
Add various improvement for integration with SignHub package

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -7,4 +7,6 @@ return [
     'timeout_seconds' => 5,
     'retry_count' => 1,
     'retry_sleep' => 10,
+
+    'custom_experience_id' => env('YOUSIGN_CUSTOM_EXPERIENCE_ID'),
 ];

--- a/database/factories/v1/InitiateSignatureRequestFactory.php
+++ b/database/factories/v1/InitiateSignatureRequestFactory.php
@@ -30,6 +30,12 @@ final class InitiateSignatureRequestFactory extends AbstractFactory
             'delivery_mode' => $this->faker->randomEnumValue(DeliveryMode::class),
             'ordered_signers' => $this->faker->boolean(),
             'timezone' => $this->faker->timezone(),
+            'email_notification' => [
+                'sender' => [
+                    'type' => 'organization',
+                ],
+                'custom_note' => $this->faker->sentence(),
+            ],
         ];
     }
 }

--- a/database/factories/v1/InitiateSignatureRequestFactory.php
+++ b/database/factories/v1/InitiateSignatureRequestFactory.php
@@ -36,6 +36,7 @@ final class InitiateSignatureRequestFactory extends AbstractFactory
                 ],
                 'custom_note' => $this->faker->sentence(),
             ],
+            'custom_experience_id' => $this->faker->uuid(),
         ];
     }
 }

--- a/database/factories/v1/InitiateSignatureRequestFactory.php
+++ b/database/factories/v1/InitiateSignatureRequestFactory.php
@@ -2,6 +2,7 @@
 
 namespace Coverzen\Components\YousignClient\Database\Factories\v1;
 
+use Coverzen\Components\YousignClient\Enums\v1\DeliveryMode;
 use Coverzen\Components\YousignClient\Structs\Soa\v1\InitiateSignatureRequest;
 
 /**
@@ -26,7 +27,7 @@ final class InitiateSignatureRequestFactory extends AbstractFactory
     {
         return [
             'name' => $this->faker->name(),
-            'delivery_mode' => 'none',
+            'delivery_mode' => $this->faker->randomEnumValue(DeliveryMode::class),
             'ordered_signers' => $this->faker->boolean(),
             'timezone' => $this->faker->timezone(),
         ];

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -27,3 +27,7 @@ parameters:
              paths:
                  - tests/Unit/Libs/Soa/v1/YousignTest.php
                  - src/Fakes/v1/YousignFaker.php
+
+        -
+             message: '#Property Coverzen\\Components\\YousignClient\\Structs\\Soa\\v1\\InitiateSignatureRequest::\$custom_experience_id \(string\|null\) does not accept mixed\.#'
+             path: src/Structs/Soa/v1/InitiateSignatureRequest.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -46,6 +46,11 @@
                 <file name="src/Fakes/v1/YousignFaker.php"/>
             </errorLevel>
         </InternalMethod>
+        <TooManyTemplateParams>
+            <errorLevel type="suppress">
+                <file name="src/Structs/Soa/v1/InitiateSignatureRequest.php"/>
+            </errorLevel>
+        </TooManyTemplateParams>
     </issueHandlers>
 
     <plugins>

--- a/src/Enums/v1/DeliveryMode.php
+++ b/src/Enums/v1/DeliveryMode.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Coverzen\Components\YousignClient\Enums\v1;
+
+use Spatie\Enum\Laravel\Enum;
+
+/**
+ * Class DeliveryMode.
+ *
+ * @method static self none()
+ * @method static self email()
+ */
+final class DeliveryMode extends Enum
+{
+}

--- a/src/Facades/v1/Yousign.php
+++ b/src/Facades/v1/Yousign.php
@@ -2,6 +2,7 @@
 
 namespace Coverzen\Components\YousignClient\Facades\v1;
 
+use Closure;
 use Coverzen\Components\YousignClient\Fakes\v1\YousignFaker;
 use Coverzen\Components\YousignClient\Libs\Soa\v1\Yousign as YousignSoaLib;
 use Coverzen\Components\YousignClient\Structs\Soa\v1\InitiateSignatureRequest;
@@ -20,7 +21,7 @@ use RuntimeException;
  *
  * @method static InitiateSignatureResponse initiateSignature(InitiateSignatureRequest $initiateSignatureRequest)
  * @method static UploadDocumentResponse uploadDocument(string $signatureRequestId, UploadDocumentRequest $uploadDocumentRequest)
- * @method static void assertIsCalled(string $functionName)
+ * @method static void assertIsCalled(string $functionName, ?Closure $callback = null)
  */
 final class Yousign extends Facade
 {
@@ -39,7 +40,7 @@ final class Yousign extends Facade
      *
      * @throws RuntimeException
      *
-     * @return string
+     * @return class-string<YousignSoaLib>
      */
     protected static function getFacadeAccessor(): string
     {

--- a/src/Fakes/v1/YousignFaker.php
+++ b/src/Fakes/v1/YousignFaker.php
@@ -2,6 +2,7 @@
 
 namespace Coverzen\Components\YousignClient\Fakes\v1;
 
+use Closure;
 use Coverzen\Components\YousignClient\Libs\Soa\v1\Soa;
 use Coverzen\Components\YousignClient\Libs\Soa\v1\Yousign;
 use Coverzen\Components\YousignClient\Structs\Soa\v1\InitiateSignatureResponse;
@@ -50,6 +51,15 @@ class YousignFaker
     private ?string $calledFunctionName = null;
 
     /**
+     * Arguments of the last called function.
+     *
+     * @see self::assertIsCalled()
+     *
+     * @var array<int,mixed>
+     */
+    private array $arguments = [];
+
+    /**
      * Constructor for `YousignFaker` class.
      */
     public function __construct()
@@ -90,18 +100,22 @@ class YousignFaker
     public function __call(string $function, array $arguments): mixed
     {
         $this->calledFunctionName = $function;
+        $this->arguments = $arguments;
 
         return (new Yousign())->{$function}(...$arguments);
     }
 
     /**
      * Function to assert a facade method is called.
+     * If a callback is provided, it will be called with the arguments of the
+     * called function.
      *
      * @param string $expectedFunctionName
+     * @param Closure|null $callback
      *
      * @return void
      */
-    public function assertIsCalled(string $expectedFunctionName): void
+    public function assertIsCalled(string $expectedFunctionName, ?Closure $callback = null): void
     {
         if (null === $this->calledFunctionName) {
             throw new ExpectationFailedException(sprintf(self::FAILED_ASSERTION_MESSAGE_NO_CALLED, $expectedFunctionName));
@@ -112,5 +126,9 @@ class YousignFaker
             $this->calledFunctionName,
             sprintf(self::FAILED_ASSERTION_MESSAGE_DIFFERENT_FUNCTION, $expectedFunctionName, $this->calledFunctionName)
         );
+
+        $callback = $callback ?: static fn (): bool => true;
+
+        PHPUnit::assertTrue($callback(...$this->arguments));
     }
 }

--- a/src/Libs/Soa/v1/Yousign.php
+++ b/src/Libs/Soa/v1/Yousign.php
@@ -70,7 +70,7 @@ class Yousign extends Soa
     public function initiateSignature(InitiateSignatureRequest $initiateSignatureRequest): InitiateSignatureResponse
     {
         /** @var Response $response */
-        $response = $this->apiClient->post(self::INITIATE_SIGNATURE_URL, $initiateSignatureRequest->toArray());
+        $response = $this->apiClient->post(self::INITIATE_SIGNATURE_URL, $initiateSignatureRequest->payload);
 
         if (!is_array($response->json())) {
             throw new RuntimeException('Yousign response is not an array.');

--- a/src/Structs/Soa/v1/InitiateSignatureRequest.php
+++ b/src/Structs/Soa/v1/InitiateSignatureRequest.php
@@ -3,13 +3,14 @@
 namespace Coverzen\Components\YousignClient\Structs\Soa\v1;
 
 use Coverzen\Components\YousignClient\Database\Factories\v1\InitiateSignatureRequestFactory;
+use Coverzen\Components\YousignClient\Enums\v1\DeliveryMode;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 /**
  * Class CreateProcedureRequest.
  *
  * @property string|null $name
- * @property string|null $delivery_mode
+ * @property DeliveryMode $delivery_mode
  * @property bool $ordered_signers
  * @property string|null $timezone
  */
@@ -31,18 +32,30 @@ final class InitiateSignatureRequest extends Struct
     /** {@inheritdoc} */
     protected $attributes = [
         'name' => null,
-        'delivery_mode' => null,
         'ordered_signers' => false,
         'timezone' => null,
     ];
 
     /** {@inheritdoc} */
     protected $casts = [
+        'delivery_mode' => DeliveryMode::class,
         'ordered_signers' => 'boolean',
     ];
 
     /**
-     * Set the proper factory for model.
+     * @param array<array-key,mixed> $attributes
+     *
+     * @return void
+     */
+    public function __construct(array $attributes = [])
+    {
+        $this->delivery_mode = DeliveryMode::none();
+
+        parent::__construct($attributes);
+    }
+
+    /**
+     * Set the proper factory for the model.
      *
      * @return InitiateSignatureRequestFactory<self>
      */

--- a/src/Structs/Soa/v1/InitiateSignatureRequest.php
+++ b/src/Structs/Soa/v1/InitiateSignatureRequest.php
@@ -4,7 +4,9 @@ namespace Coverzen\Components\YousignClient\Structs\Soa\v1;
 
 use Coverzen\Components\YousignClient\Database\Factories\v1\InitiateSignatureRequestFactory;
 use Coverzen\Components\YousignClient\Enums\v1\DeliveryMode;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use function collect;
 
 /**
  * Class CreateProcedureRequest.
@@ -13,6 +15,8 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
  * @property DeliveryMode $delivery_mode
  * @property bool $ordered_signers
  * @property string|null $timezone
+ * @property array|null $email_notification
+ * @property-read array $payload
  */
 final class InitiateSignatureRequest extends Struct
 {
@@ -27,6 +31,7 @@ final class InitiateSignatureRequest extends Struct
         'delivery_mode',
         'ordered_signers',
         'timezone',
+        'email_notification',
     ];
 
     /** {@inheritdoc} */
@@ -62,5 +67,21 @@ final class InitiateSignatureRequest extends Struct
     protected static function newFactory(): InitiateSignatureRequestFactory
     {
         return InitiateSignatureRequestFactory::new();
+    }
+
+    /**
+     * Define accessor for `payload` attribute.
+     * It basically removes all null properties.
+     *
+     * @return Attribute<array<array-key,mixed>,null>
+     */
+    protected function payload(): Attribute
+    {
+        return Attribute::make(
+            get: function (): array {
+                return collect($this->getAttributes())->filter(static fn ($value): bool => $value !== null)
+                                                      ->toArray();
+            }
+        );
     }
 }

--- a/src/Structs/Soa/v1/InitiateSignatureRequest.php
+++ b/src/Structs/Soa/v1/InitiateSignatureRequest.php
@@ -4,8 +4,10 @@ namespace Coverzen\Components\YousignClient\Structs\Soa\v1;
 
 use Coverzen\Components\YousignClient\Database\Factories\v1\InitiateSignatureRequestFactory;
 use Coverzen\Components\YousignClient\Enums\v1\DeliveryMode;
+use Coverzen\Components\YousignClient\YousignClientServiceProvider;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Facades\Config;
 use function collect;
 
 /**
@@ -16,6 +18,7 @@ use function collect;
  * @property bool $ordered_signers
  * @property string|null $timezone
  * @property array|null $email_notification
+ * @property string|null $custom_experience_id
  * @property-read array $payload
  */
 final class InitiateSignatureRequest extends Struct
@@ -54,9 +57,10 @@ final class InitiateSignatureRequest extends Struct
      */
     public function __construct(array $attributes = [])
     {
-        $this->delivery_mode = DeliveryMode::none();
-
         parent::__construct($attributes);
+
+        $this->delivery_mode = DeliveryMode::none();
+        $this->custom_experience_id = Config::get(YousignClientServiceProvider::CONFIG_KEY . '.custom_experience_id');
     }
 
     /**

--- a/src/Structs/Soa/v1/Struct.php
+++ b/src/Structs/Soa/v1/Struct.php
@@ -46,7 +46,7 @@ abstract class Struct extends Model
     protected static function booted(): void
     {
         static::saving(
-            static function (): void {
+            static function () {
                 throw new StructSaveException();
             }
         );

--- a/tests/Unit/Libs/Soa/v1/YousignTest.php
+++ b/tests/Unit/Libs/Soa/v1/YousignTest.php
@@ -31,12 +31,22 @@ final class YousignTest extends TestCase
     /** @var string */
     private const SIGNATURE_ID = '0da2b825-3682-4d42-bcd0-d01f791940ff';
 
-    /** @var array<int,string> */
-    private const INITIATE_PROCEDURE_REQUIRED_PROPERTIES = [
-        'name',
-        'delivery_mode',
-        'timezone',
-    ];
+    /**
+     * Provides a set of properties to set null.
+     *
+     * @return array<string,array<string,mixed>>
+     */
+    public static function nullPropertiesProvider(): array
+    {
+        return [
+            'no ordered_signers' => [
+                'nullProperty' => 'ordered_signers',
+            ],
+            'no email_notification' => [
+                'nullProperty' => 'email_notification',
+            ],
+        ];
+    }
 
     /**
      * @test
@@ -51,9 +61,13 @@ final class YousignTest extends TestCase
     /**
      * @test
      * @covers      ::initiateSignature
+     * @dataProvider nullPropertiesProvider
+     *
+     * @param string $nullProperty
+     *
      * @return void
      */
-    public function it_initiates_a_procedure(): void
+    public function it_initiates_a_procedure(string $nullProperty): void
     {
         /** @var string $url */
         $url = Str::finish(
@@ -73,43 +87,40 @@ final class YousignTest extends TestCase
 
         /** @var InitiateSignatureRequest $initiateSignatureRequest */
         $initiateSignatureRequest = InitiateSignatureRequest::factory()
-                                                            ->make();
+                                                            ->make(
+                                                                [
+                                                                    $nullProperty => null,
+                                                                ]
+                                                            );
 
         /** @var InitiateSignatureResponse|null $actualSignatureResponse */
         $actualSignatureResponse = (new Yousign())->initiateSignature($initiateSignatureRequest);
 
         Http::assertSent(
-            static function (ClientRequest $request) use ($initiateSignatureRequest, $url): bool {
-                if ($request->method() !== Request::METHOD_POST) {
-                    throw new ExpectationFailedException('Request method must be POST');
-                }
+            function (ClientRequest $request) use ($initiateSignatureRequest, $url, $nullProperty): bool {
+                $this->assertSame(Request::METHOD_POST, $request->method());
+                $this->assertSame($url, $request->url());
 
-                if (
-                    $request->url() !== $url
-                ) {
-                    throw new ExpectationFailedException('Request URL must be ' . Config::get(YousignClientServiceProvider::CONFIG_KEY . '.url') . Yousign::INITIATE_SIGNATURE_URL);
-                }
+                $this->assertSame(
+                    Yousign::BEARER_PREFIX . Config::get(YousignClientServiceProvider::CONFIG_KEY . '.api_key'),
+                    Arr::first($request->header(Soa::AUTHORIZATION_HEADER))
+                );
 
-                if (
-                    !in_array(
-                        Yousign::BEARER_PREFIX . Config::get(YousignClientServiceProvider::CONFIG_KEY . '.api_key'),
-                        $request->header(Soa::AUTHORIZATION_HEADER),
-                        true
-                    )
-                ) {
-                    throw new ExpectationFailedException(Soa::AUTHORIZATION_HEADER . ' header missing or with wrong value.');
-                }
+                $this->assertContains(
+                    Yousign::BEARER_PREFIX . Config::get(YousignClientServiceProvider::CONFIG_KEY . '.api_key'),
+                    $request->header(Soa::AUTHORIZATION_HEADER)
+                );
 
-                /** @var string $property */
-                foreach (self::INITIATE_PROCEDURE_REQUIRED_PROPERTIES as $property) {
-                    if (!Arr::has($request->data(), $property)) {
-                        throw new ExpectationFailedException("Property {$property} missing in request payload.");
-                    }
+                $this->assertArrayNotHasKey($nullProperty, $request->data());
 
-                    if (Arr::get($request->data(), $property) !== $initiateSignatureRequest->{$property}) {
-                        throw new ExpectationFailedException("Property {$property} in request payload has wrong value " . Arr::get($request->data(), $property) . '.');
-                    }
-                }
+                $this->assertArrayHasKey('name', $request->data());
+                $this->assertSame($initiateSignatureRequest->name, $request->data()['name']);
+
+                $this->assertArrayHasKey('timezone', $request->data());
+                $this->assertSame($initiateSignatureRequest->timezone, $request->data()['timezone']);
+
+                $this->assertArrayHasKey('delivery_mode', $request->data());
+                $this->assertSame($initiateSignatureRequest->delivery_mode->value, $request->data()['delivery_mode']);
 
                 return true;
             }

--- a/tests/Unit/Structs/Soa/v1/InitiateSignatureRequestTest.php
+++ b/tests/Unit/Structs/Soa/v1/InitiateSignatureRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Coverzen\Components\YousignClient\Tests\Unit\Structs\Soa\v1;
 
+use Coverzen\Components\YousignClient\Enums\v1\DeliveryMode;
 use Coverzen\Components\YousignClient\Exceptions\Structs\v1\StructSaveException;
 use Coverzen\Components\YousignClient\Structs\Soa\v1\InitiateSignatureRequest;
 
@@ -52,9 +53,23 @@ final class InitiateSignatureRequestTest extends TestCase
                                                             ->make();
 
         $this->assertIsString($initiateSignatureRequest->name);
-        $this->assertIsString($initiateSignatureRequest->delivery_mode);
+        $this->assertInstanceOf(DeliveryMode::class, $initiateSignatureRequest->delivery_mode);
         $this->assertIsBool($initiateSignatureRequest->ordered_signers);
         $this->assertIsString($initiateSignatureRequest->timezone);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function it_has_default_properties_values(): void
+    {
+        /** @var InitiateSignatureRequest $initiateSignatureRequest */
+        $initiateSignatureRequest = InitiateSignatureRequest::factory()
+                                                            ->make();
+
+        $this->assertSame(DeliveryMode::none(), $initiateSignatureRequest->delivery_mode);
     }
 
     /**

--- a/tests/Unit/Structs/Soa/v1/InitiateSignatureRequestTest.php
+++ b/tests/Unit/Structs/Soa/v1/InitiateSignatureRequestTest.php
@@ -56,6 +56,7 @@ final class InitiateSignatureRequestTest extends TestCase
         $this->assertInstanceOf(DeliveryMode::class, $initiateSignatureRequest->delivery_mode);
         $this->assertIsBool($initiateSignatureRequest->ordered_signers);
         $this->assertIsString($initiateSignatureRequest->timezone);
+        $this->assertIsArray($initiateSignatureRequest->email_notification);
     }
 
     /**
@@ -96,5 +97,57 @@ final class InitiateSignatureRequestTest extends TestCase
         $this->expectException(StructSaveException::class);
 
         (new InitiateSignatureRequest())->save();
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function it_has_payload_accessor(): void
+    {
+        /** @var InitiateSignatureRequest $initiateSignatureRequest */
+        $initiateSignatureRequest = InitiateSignatureRequest::factory()
+                                                            ->make();
+
+        $this->assertNotNull($initiateSignatureRequest->payload);
+        $this->assertIsArray($initiateSignatureRequest->payload);
+
+        $this->assertArrayNotHasKey('payload', $initiateSignatureRequest->payload);
+
+        $this->assertArrayHasKey('name', $initiateSignatureRequest->payload);
+        $this->assertArrayHasKey('delivery_mode', $initiateSignatureRequest->payload);
+        $this->assertArrayHasKey('ordered_signers', $initiateSignatureRequest->payload);
+        $this->assertArrayHasKey('timezone', $initiateSignatureRequest->payload);
+        $this->assertArrayHasKey('email_notification', $initiateSignatureRequest->payload);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function it_removes_null_values_in_payload_accessor(): void
+    {
+        /** @var InitiateSignatureRequest $initiateSignatureRequest */
+        $initiateSignatureRequest = InitiateSignatureRequest::factory()
+                                                            ->make(
+                                                                [
+                                                                    'name' => null,
+                                                                    'ordered_signers' => null,
+                                                                    'timezone' => null,
+                                                                    'email_notification' => null,
+                                                                ]
+                                                            );
+
+        $this->assertNotNull($initiateSignatureRequest->payload);
+        $this->assertIsArray($initiateSignatureRequest->payload);
+
+        $this->assertArrayNotHasKey('payload', $initiateSignatureRequest->payload);
+
+        $this->assertArrayNotHasKey('name', $initiateSignatureRequest->payload);
+        $this->assertArrayNotHasKey('ordered_signers', $initiateSignatureRequest->payload);
+        $this->assertArrayNotHasKey('timezone', $initiateSignatureRequest->payload);
+        $this->assertArrayNotHasKey('email_notification', $initiateSignatureRequest->payload);
     }
 }

--- a/tests/Unit/Structs/Soa/v1/InitiateSignatureRequestTest.php
+++ b/tests/Unit/Structs/Soa/v1/InitiateSignatureRequestTest.php
@@ -66,8 +66,7 @@ final class InitiateSignatureRequestTest extends TestCase
     public function it_has_default_properties_values(): void
     {
         /** @var InitiateSignatureRequest $initiateSignatureRequest */
-        $initiateSignatureRequest = InitiateSignatureRequest::factory()
-                                                            ->make();
+        $initiateSignatureRequest = new InitiateSignatureRequest();
 
         $this->assertSame(DeliveryMode::none(), $initiateSignatureRequest->delivery_mode);
     }


### PR DESCRIPTION
### What kind of change does this PR introduce?
Feature

### What is the new behavior?
- add enum for delivery mode
- add inspection of arguments passed to facade functions

### Does this PR introduce a breaking change?
No

### Other information:
It's now possible to inspect the arguments passed to the facade functions, to make assertions on them.

e.g.

```php
YousignFacade::assertIsCalled(
    'initiateSignature',
    function (InitiateSignatureRequest $request) use ($procedure) :bool {
        $this->assertSame($procedure->getName(), $request->name);
        $this->assertSame(DeliveryMode::none(), $request->delivery_mode);

       return true;
    }
);
```
