### PR TITLE
Add external_id to InitiateSignatureRequest (CZDEV-2252)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ assigning properties. Enum fields accept native enum instances.
 | `ordered_signers`    | `bool`                      | Defaults to `false`.                          |
 | `timezone`           | `string\|null`              | e.g. `Europe/Rome`.                           |
 | `email_notification` | `array<string,mixed>\|null` | Optional email notification settings.         |
+| `external_id`        | `string\|null`              | Your correlation id, echoed back in webhooks. |
 
 > `custom_experience_id` is injected automatically from config (`YOUSIGN_CUSTOM_EXPERIENCE_ID`) when set.
 

--- a/src/Structs/Soa/v1/InitiateSignatureRequest.php
+++ b/src/Structs/Soa/v1/InitiateSignatureRequest.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Facades\Config;
  * @property string|null $timezone
  * @property array<string,mixed>|null $email_notification
  * @property string|null $custom_experience_id
+ * @property string|null $external_id
  */
 final class InitiateSignatureRequest extends Request
 {
@@ -30,6 +31,7 @@ final class InitiateSignatureRequest extends Request
         'ordered_signers',
         'timezone',
         'email_notification',
+        'external_id',
     ];
 
     /** {@inheritdoc} */

--- a/tests/Unit/Structs/Soa/v1/InitiateSignatureRequestTest.php
+++ b/tests/Unit/Structs/Soa/v1/InitiateSignatureRequestTest.php
@@ -7,6 +7,7 @@ use Coverzen\Components\YousignClient\Exceptions\Structs\v1\StructSaveException;
 use Coverzen\Components\YousignClient\Structs\Soa\v1\InitiateSignatureRequest;
 use Coverzen\Components\YousignClient\YousignClientServiceProvider;
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Class InitiateSignatureRequestTest.
@@ -17,6 +18,9 @@ final class InitiateSignatureRequestTest extends TestCase
 {
     /** @var string */
     private const FAKE_CUSTOM_EXPERIENCE_ID = 'fake-custom-experience-id';
+
+    /** @var string */
+    private const FAKE_EXTERNAL_ID = 'internal-process-uuid';
 
     /**
      * @test
@@ -223,5 +227,35 @@ final class InitiateSignatureRequestTest extends TestCase
         } else {
             $this->assertArrayNotHasKey('custom_experience_id', $initiateSignatureRequest->payload);
         }
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function it_includes_external_id_in_payload_when_set(): void
+    {
+        /** @var InitiateSignatureRequest $initiateSignatureRequest */
+        $initiateSignatureRequest = new InitiateSignatureRequest(['external_id' => self::FAKE_EXTERNAL_ID]);
+
+        $this->assertSame(self::FAKE_EXTERNAL_ID, $initiateSignatureRequest->external_id);
+
+        $this->assertArrayHasKey('external_id', $initiateSignatureRequest->payload);
+        $this->assertSame(self::FAKE_EXTERNAL_ID, $initiateSignatureRequest->payload['external_id']);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function it_omits_external_id_from_payload_when_not_set(): void
+    {
+        /** @var InitiateSignatureRequest $initiateSignatureRequest */
+        $initiateSignatureRequest = InitiateSignatureRequest::factory()
+                                                            ->make();
+
+        $this->assertNull($initiateSignatureRequest->external_id);
+
+        $this->assertArrayNotHasKey('external_id', $initiateSignatureRequest->payload);
     }
 }


### PR DESCRIPTION
## Summary

Adds `external_id` to `InitiateSignatureRequest`, the robust correlation key used to reconcile Yousign webhooks with the caller's internal process. It is now mass-assignable and flows into the `POST /signature_requests` payload when set.

## Changes

- `external_id` added to `$fillable` + `@property` on `InitiateSignatureRequest`.
- Tests: payload includes `external_id` when set (via guarded mass-assignment, the real consumer path), omits it when unset.
- README: documented `external_id` in the `InitiateSignatureRequest` field table.

## CZDEV-2252 acceptance criteria

- ✅ `external_id` settable on creation and verified in tests.
- ✅ Laravel 12 & 13 already covered by the CI matrix (`tests.yml`).
- ⤷ Coordinate-conversion helper: **dropped by design**. The microservice convention aligns natively with Yousign (top-left origin, PDF points @72dpi, 1-based page), and `SignerField` already exposes `x/y/width/height/page` (covered by `SignerFieldTest`). No Y-axis inversion / A4 hardcoding needed — the legacy `signhub` helper is obsolete.
- ⤷ New release: to be tagged by the maintainer (semantic-release on merge).

## Testing

`composer test` (107 passing) and `composer analyse` green on PHP 8.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)