### PR TITLE
Require `file_name` on document upload (fail-fast) [CZDEV-2312]

### DIFF
--- a/src/Libs/Soa/v1/Yousign.php
+++ b/src/Libs/Soa/v1/Yousign.php
@@ -123,6 +123,10 @@ class Yousign extends Soa
             throw new RuntimeException('File content is required.');
         }
 
+        if (!$uploadDocumentRequest->file_name) {
+            throw new RuntimeException('File name is required.');
+        }
+
         /**
          * The client is cloned so that the `attach()` method doesn't change headers for all the following requests.
          *

--- a/src/Structs/Soa/v1/UploadDocumentRequest.php
+++ b/src/Structs/Soa/v1/UploadDocumentRequest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
  * Class UploadDocumentRequest.
  *
  * @property string|null $file_content
- * @property string|null $file_name
+ * @property string $file_name
  * @property DocumentNature $nature
  * @property-read array<string,mixed> $payload
  */
@@ -22,6 +22,11 @@ final class UploadDocumentRequest extends Request
     /** {@inheritdoc} */
     protected $casts = [
         'nature' => DocumentNature::class,
+    ];
+
+    /** {@inheritdoc} */
+    protected array $rules = [
+        'file_name' => ['required', 'string'],
     ];
 
     /** {@inheritdoc} */

--- a/tests/Unit/Libs/Soa/v1/YousignTest.php
+++ b/tests/Unit/Libs/Soa/v1/YousignTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\ExpectationFailedException;
+use RuntimeException;
 use function implode;
 
 #[CoversClass(Yousign::class)]
@@ -277,6 +278,28 @@ final class YousignTest extends TestCase
             $expectedUploadDocumentResponse->toArray(),
             $actualUploadDocumentResponse->toArray()
         );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function it_throws_an_exception_when_file_name_is_missing(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('File name is required.');
+
+        Http::preventStrayRequests();
+
+        /** @var UploadDocumentRequest $uploadDocumentRequest */
+        $uploadDocumentRequest = UploadDocumentRequest::factory()
+                                                      ->make(
+                                                          [
+                                                              'file_name' => null,
+                                                          ]
+                                                      );
+
+        (new Yousign())->uploadDocument(self::SIGNATURE_ID, $uploadDocumentRequest);
     }
 
     /**


### PR DESCRIPTION
## Contesto

L'endpoint Yousign `POST /signature_requests/{id}/documents` richiede il part multipart `file` con un `filename`: senza `filename=` nel `Content-Disposition` il part viaggia come campo testo e Yousign risponde `400 parameters_not_valid` → `{"name":"file","reason":"This value should not be null."}`.

Prima il client accettava `file_name` null e falliva tardi e in modo opaco: nessun guard su `file_name`, valore null passato direttamente ad `attach()`.

## Cosa cambia

- **`UploadDocumentRequest`**: `file_name` ora `@property string` (non-null) + `$rules` con `'file_name' => ['required','string']`.
- **`Yousign::uploadDocument`**: guard simmetrico a quello su `file_content` — `RuntimeException('File name is required.')` prima dell'`attach()`, senza chiamare Yousign.
- **Test (TDD)**: `it_throws_an_exception_when_file_name_is_missing` con `expectExceptionMessage` e `preventStrayRequests`. Il caso con `file_name` valorizzato resta verde.

La factory generava già sempre un `file_name` valido — nessuna modifica necessaria, `YousignFaker` resta coerente.

## Acceptance Criteria

- [x] `file_name` obbligatorio nello Struct (tipo non-null + regola `required`)
- [x] `uploadDocument` fallisce con `RuntimeException('File name is required.')` se `file_name` assente, senza chiamare Yousign
- [x] factory genera sempre `file_name` valido; `YousignFaker` coerente
- [x] `composer analyse` e `composer test` verdi

## Fuori scope

- Fix lato `digital-signature-service` (fornire il filename per i doc DMS) — tracciato a parte
- Logging request/response del client — CZDEV-2311

Refs: CZDEV-2312