### PR TITLE
Log Yousign request/response on a dedicated channel [CZDEV-2311]

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+use Coverzen\Components\YousignClient\YousignClientServiceProvider;
+use Illuminate\Support\Facades\App;
+
+return [
+    /*
+     |--------------------------------------------------------------------------
+     | Yousign Client Log Channels
+     |--------------------------------------------------------------------------
+     |
+     | Custom logging channels for Yousign client operations.
+     |
+     */
+
+    'channels' => [
+        YousignClientServiceProvider::LOG_CHANNEL => [
+            'driver' => 'stack',
+            'channels' => explode(
+                ',',
+                (string) env('YOUSIGN_LOG_STACK', YousignClientServiceProvider::LOG_CHANNEL . '-local')
+            ),
+            'ignore_exceptions' => false,
+            'name' => YousignClientServiceProvider::LOG_CHANNEL . '-' . App::environment(),
+        ],
+
+        YousignClientServiceProvider::LOG_CHANNEL . '-local' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/yousign-client.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'days' => 14,
+        ],
+    ],
+];

--- a/src/Listeners/v1/LogRequestAndResponse.php
+++ b/src/Listeners/v1/LogRequestAndResponse.php
@@ -1,0 +1,160 @@
+<?php declare(strict_types=1);
+
+namespace Coverzen\Components\YousignClient\Listeners\v1;
+
+use Coverzen\Components\YousignClient\YousignClientServiceProvider;
+use Illuminate\Http\Client\Events\ResponseReceived;
+use Illuminate\Http\Response;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use RuntimeException;
+use function array_keys;
+use function explode;
+use function in_array;
+
+/**
+ * Class LogRequestAndResponse.
+ */
+final class LogRequestAndResponse
+{
+    /** @var string */
+    public const REQUEST_LOG_MESSAGE = 'Request:  ';
+
+    /** @var string */
+    public const REDACTED = '***REDACTED***';
+
+    /**
+     * Headers redacted from the logged context because they carry secrets
+     * (e.g. the Yousign `Authorization: Bearer <API key>` header).
+     *
+     * @var array<int,string>
+     */
+    private const SENSITIVE_HEADERS = [
+        'authorization',
+    ];
+
+    /**
+     * Handle the event.
+     *
+     * @param ResponseReceived $event
+     *
+     * @throws RuntimeException
+     */
+    public function handle(ResponseReceived $event): void
+    {
+        if (!Config::get(YousignClientServiceProvider::CONFIG_KEY . '.url')) {
+            return;
+        }
+
+        /** @var string $expectedHost */
+        $expectedHost = Arr::get(
+            explode(
+                '//',
+                Config::string(YousignClientServiceProvider::CONFIG_KEY . '.url')
+            ),
+            1,
+            ''
+        );
+
+        /** @var string $actualHost */
+        foreach ($event->request->header('Host') as $actualHost) {
+            if (!Str::startsWith($expectedHost, $actualHost)) {
+                return;
+            }
+        }
+
+        /** @var RequestInterface $request */
+        $request = $event->request->toPsrRequest();
+
+        /** @var ResponseInterface $response */
+        $response = $event->response->toPsrResponse();
+
+        /** @var string $body */
+        $body = $response->getBody()->getContents();
+
+        /**
+         * Rewind the request body stream before reading it.
+         *
+         * @var StreamInterface $requestBodyStream
+         */
+        $requestBodyStream = $request->getBody();
+        $requestBodyStream->rewind();
+
+        /** @var non-falsy-string $message */
+        $message = self::REQUEST_LOG_MESSAGE . $request->getUri()->getPath();
+
+        /** @var array<array-key,array<array-key,mixed>> $context */
+        $context = [
+            'request' => [
+                'protocol_version' => $request->getProtocolVersion(),
+                'method' => $request->getMethod(),
+                'scheme' => $request->getUri()->getScheme(),
+                'host' => $request->getUri()->getHost(),
+                'port' => $request->getUri()->getPort(),
+                'path' => $request->getUri()->getPath(),
+                'authority' => $request->getUri()->getAuthority(),
+                'query' => $request->getUri()->getQuery(),
+                'fragment' => $request->getUri()->getFragment(),
+                'user_info' => $request->getUri()->getUserInfo(),
+                'headers' => $this->redactHeaders($request->getHeaders()),
+                'request_target' => $request->getRequestTarget(),
+                'body' => $requestBodyStream->getContents(),
+            ],
+            'response' => [
+                'protocol' => $response->getProtocolVersion(),
+                'status_code' => $response->getStatusCode(),
+                'headers' => $response->getHeaders(),
+                'body' => $body,
+                'reason_phrase' => $response->getReasonPhrase(),
+            ],
+        ];
+
+        if ($response->getStatusCode() < Response::HTTP_MULTIPLE_CHOICES) {
+            Log::channel(YousignClientServiceProvider::LOG_CHANNEL)
+               ->info($message, $context);
+
+            return;
+        }
+
+        if ($response->getStatusCode() < Response::HTTP_BAD_REQUEST) {
+            Log::channel(YousignClientServiceProvider::LOG_CHANNEL)
+               ->notice($message, $context);
+
+            return;
+        }
+
+        if ($response->getStatusCode() < Response::HTTP_INTERNAL_SERVER_ERROR) {
+            Log::channel(YousignClientServiceProvider::LOG_CHANNEL)
+               ->warning($message, $context);
+
+            return;
+        }
+
+        Log::channel(YousignClientServiceProvider::LOG_CHANNEL)
+           ->error($message, $context);
+    }
+
+    /**
+     * Redact sensitive headers (e.g. the Yousign Bearer API key) before logging.
+     *
+     * @param array<array-key,array<array-key,string>> $headers
+     *
+     * @return array<array-key,array<array-key,string>>
+     */
+    private function redactHeaders(array $headers): array
+    {
+        /** @var array-key $name */
+        foreach (array_keys($headers) as $name) {
+            if (in_array(Str::lower((string) $name), self::SENSITIVE_HEADERS, true)) {
+                $headers[$name] = [self::REDACTED];
+            }
+        }
+
+        return $headers;
+    }
+}

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Coverzen\Components\YousignClient\Providers;
+
+use Coverzen\Components\YousignClient\Listeners\v1\LogRequestAndResponse;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Http\Client\Events\ResponseReceived;
+
+/**
+ * Class EventServiceProvider.
+ */
+final class EventServiceProvider extends ServiceProvider
+{
+    /** {@inheritdoc} */
+    protected $listen = [
+        ResponseReceived::class => [
+            LogRequestAndResponse::class,
+        ],
+    ];
+}

--- a/src/YousignClientServiceProvider.php
+++ b/src/YousignClientServiceProvider.php
@@ -2,7 +2,12 @@
 
 namespace Coverzen\Components\YousignClient;
 
+use Coverzen\Components\YousignClient\Providers\EventServiceProvider;
+use Illuminate\Config\Repository;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
+use function array_merge;
 use function config_path;
 
 /**
@@ -12,6 +17,9 @@ final class YousignClientServiceProvider extends ServiceProvider
 {
     /** @var string */
     public const CONFIG_KEY = 'yousign-client';
+
+    /** @var string */
+    public const LOG_CHANNEL = 'yousign-client';
 
     /**
      * @return void
@@ -27,10 +35,34 @@ final class YousignClientServiceProvider extends ServiceProvider
     }
 
     /**
+     * @throws BindingResolutionException
      * @return void
      */
     public function register(): void
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/config.php', self::CONFIG_KEY);
+        $this->mergeLoggingChannels();
+        $this->app->register(EventServiceProvider::class);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     * @return void
+     */
+    private function mergeLoggingChannels(): void
+    {
+        /** @var array<array-key,array<array-key,mixed>> $packageLoggingConfig */
+        $packageLoggingConfig = require __DIR__ . '/../config/logging.php';
+
+        /** @var Repository $config */
+        $config = $this->app->make('config');
+
+        $config->set(
+            'logging.channels',
+            array_merge(
+                (array) Arr::get($packageLoggingConfig, 'channels', []),
+                (array) $config->get('logging.channels', [])
+            )
+        );
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,9 @@
 namespace Coverzen\Components\YousignClient\Tests;
 
 use Coverzen\Components\YousignClient\YousignClientServiceProvider;
+use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
 /**
@@ -16,6 +18,7 @@ abstract class TestCase extends BaseTestCase
         parent::setUp();
 
         Config::set('app.faker_locale', 'it_IT');
+        Event::fake(ResponseReceived::class);
     }
 
     /**

--- a/tests/Unit/Listeners/TestCase.php
+++ b/tests/Unit/Listeners/TestCase.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Coverzen\Components\YousignClient\Tests\Unit\Listeners;
+
+use Coverzen\Components\YousignClient\Tests\Unit\TestCase as BaseTestCase;
+
+/**
+ * Abstract Class TestCase.
+ */
+abstract class TestCase extends BaseTestCase
+{
+}

--- a/tests/Unit/Listeners/v1/LogRequestAndResponseTest.php
+++ b/tests/Unit/Listeners/v1/LogRequestAndResponseTest.php
@@ -1,0 +1,147 @@
+<?php declare(strict_types=1);
+
+namespace Coverzen\Components\YousignClient\Tests\Unit\Listeners\v1;
+
+use Coverzen\Components\YousignClient\Libs\Soa\v1\Soa;
+use Coverzen\Components\YousignClient\Listeners\v1\LogRequestAndResponse;
+use Coverzen\Components\YousignClient\YousignClientServiceProvider;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Http\Client\Events\ResponseReceived;
+use Illuminate\Http\Client\Request as ClientRequest;
+use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Http\Request as IlluminateRequest;
+use Illuminate\Http\Response as IlluminateResponse;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Class LogRequestAndResponseTest.
+ */
+#[CoversClass(LogRequestAndResponse::class)]
+final class LogRequestAndResponseTest extends TestCase
+{
+    /** @var string */
+    private const API_KEY = 'super-secret-api-key';
+
+    /**
+     * @return array<string,array<string,int|string>>
+     */
+    public static function responsesStatusProvider(): array
+    {
+        return [
+            'ok' => [
+                'statusCode' => IlluminateResponse::HTTP_OK,
+                'logFunction' => 'info',
+            ],
+            'redirect' => [
+                'statusCode' => IlluminateResponse::HTTP_MULTIPLE_CHOICES,
+                'logFunction' => 'notice',
+            ],
+            'bad request' => [
+                'statusCode' => IlluminateResponse::HTTP_BAD_REQUEST,
+                'logFunction' => 'warning',
+            ],
+            'server error' => [
+                'statusCode' => IlluminateResponse::HTTP_SERVICE_UNAVAILABLE,
+                'logFunction' => 'error',
+            ],
+        ];
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function it_listens_to_event(): void
+    {
+        Event::assertListening(ResponseReceived::class, LogRequestAndResponse::class);
+    }
+
+    /**
+     * @param int $statusCode
+     * @param string $logFunction
+     *
+     * @return void
+     */
+    #[Test]
+    #[DataProvider('responsesStatusProvider')]
+    public function it_logs_request_and_response(int $statusCode, string $logFunction): void
+    {
+        /** @var Request $request */
+        $request = new Request(IlluminateRequest::METHOD_POST, Config::string(YousignClientServiceProvider::CONFIG_KEY . '.url'));
+
+        Log::expects("channel->{$logFunction}")
+           ->once()
+           ->withSomeOfArgs(LogRequestAndResponse::REQUEST_LOG_MESSAGE . $request->getUri()->getPath());
+
+        (new LogRequestAndResponse())->handle(
+            new ResponseReceived(
+                new ClientRequest($request),
+                new ClientResponse(new Response($statusCode))
+            )
+        );
+    }
+
+    /**
+     * @param int $statusCode
+     * @param string $logFunction
+     *
+     * @return void
+     */
+    #[Test]
+    #[DataProvider('responsesStatusProvider')]
+    public function it_doesnt_log_request_and_response_for_http_calls_to_a_different_endpoint(int $statusCode, string $logFunction): void
+    {
+        Log::expects("channel->{$logFunction}")
+           ->never();
+
+        (new LogRequestAndResponse())->handle(
+            new ResponseReceived(
+                new ClientRequest(new Request(IlluminateRequest::METHOD_POST, 'https://other-url.com')),
+                new ClientResponse(new Response($statusCode))
+            )
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function it_redacts_the_authorization_header(): void
+    {
+        Log::expects('channel->info')
+           ->once()
+           ->withArgs(function (string $message, array $context): bool {
+               /** @var array<string,array<int,string>> $headers */
+               $headers = Arr::get($context, 'request.headers', []);
+
+               $this->assertSame(
+                   [LogRequestAndResponse::REDACTED],
+                   Arr::get($headers, Soa::AUTHORIZATION_HEADER)
+               );
+
+               return true;
+           });
+
+        (new LogRequestAndResponse())->handle(
+            new ResponseReceived(
+                new ClientRequest(
+                    new Request(
+                        IlluminateRequest::METHOD_POST,
+                        Config::string(YousignClientServiceProvider::CONFIG_KEY . '.url'),
+                        [
+                            Soa::AUTHORIZATION_HEADER => Soa::BEARER_PREFIX . self::API_KEY,
+                        ]
+                    )
+                ),
+                new ClientResponse(new Response(IlluminateResponse::HTTP_OK))
+            )
+        );
+    }
+}

--- a/tests/Unit/Listeners/v1/TestCase.php
+++ b/tests/Unit/Listeners/v1/TestCase.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Coverzen\Components\YousignClient\Tests\Unit\Listeners\v1;
+
+use Coverzen\Components\YousignClient\Tests\Unit\Listeners\TestCase as BaseTestCase;
+
+/**
+ * Abstract Class TestCase.
+ */
+abstract class TestCase extends BaseTestCase
+{
+}

--- a/tests/Unit/YousignClientServiceProviderTest.php
+++ b/tests/Unit/YousignClientServiceProviderTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Coverzen\Components\YousignClient\Tests\Unit;
+
+use Coverzen\Components\YousignClient\YousignClientServiceProvider;
+use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Class YousignClientServiceProviderTest.
+ */
+#[CoversClass(YousignClientServiceProvider::class)]
+final class YousignClientServiceProviderTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    #[Test]
+    public function it_has_config(): void
+    {
+        $this->assertNotNull(Config::get(YousignClientServiceProvider::CONFIG_KEY));
+        $this->assertIsArray(Config::get(YousignClientServiceProvider::CONFIG_KEY));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function it_registers_the_log_channel(): void
+    {
+        $this->assertNotNull(Config::get('logging.channels.' . YousignClientServiceProvider::LOG_CHANNEL));
+        $this->assertNotNull(Config::get('logging.channels.' . YousignClientServiceProvider::LOG_CHANNEL . '-local'));
+    }
+}


### PR DESCRIPTION
## Contesto

Il package non logga le request/response HTTP verso Yousign: l'unica traccia era `Soa::logClientFailure`, che registra solo i fallimenti e solo `$e->getMessage()` (troncato). Il package `dms-client` logga invece ogni request+response su un channel dedicato. Questa card replica quel pattern per avere la stessa osservabilità sulle integrazioni di firma.

## Cosa cambia (clonando il pattern dms-client)

- **`YousignClientServiceProvider`**: nuova const `LOG_CHANNEL`, `mergeLoggingChannels()` per fondere i channel del package nella config dell'app, registrazione di `EventServiceProvider`.
- **`config/logging.php`** (nuovo): stack `yousign-client` + `yousign-client-local` (driver `daily`, `storage/logs/yousign-client.log`, 14 giorni), pilotato dall'env `YOUSIGN_LOG_STACK`.
- **`src/Providers/EventServiceProvider.php`** (nuovo): mappa `ResponseReceived` → `LogRequestAndResponse`.
- **`src/Listeners/v1/LogRequestAndResponse.php`** (nuovo): logga request (method, uri, headers, body) e response (status, headers, body), filtrando sull'host Yousign; livello in base allo status (info `<300`, notice `<400`, warning `<500`, error `>=500`).

## Sicurezza

A differenza del `dms-client` (presigned URL, nessun bearer), le chiamate Yousign portano `Authorization: Bearer <API key>`. L'header `Authorization` viene **redatto** (`***REDACTED***`) nel context loggato: nessuna API key in chiaro nei log. Coperto dal test `it_redacts_the_authorization_header`.

## Acceptance Criteria

- [x] ogni chiamata Yousign produce una riga sul channel `yousign-client` con request e response complete
- [x] livello di log coerente con lo status HTTP (info/notice/warning/error)
- [x] header `Authorization` mascherato: nessuna API key in chiaro nei log
- [x] channel registrato via merge config; in locale scrive `storage/logs/yousign-client.log`
- [x] `composer analyse` e `composer test` verdi (PHPStan livello 10, Psalm, php-cs-fixer, ecc.)

## Note

- Aggiunto `Event::fake(ResponseReceived::class)` al `TestCase` base (come in dms-client): abilita `Event::assertListening` ed evita che il listener scatti durante gli altri test.
- Fuori scope: nessuna modifica a `digital-signature-service` (il logging vive nel package, riusabile da ogni consumer).

Refs: CZDEV-2311