### PR TITLE
Validate signer info before sending the add-signer request (CZDEV-2252)

### DIFF
--- a/src/Enums/v1/Locale.php
+++ b/src/Enums/v1/Locale.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Coverzen\Components\YousignClient\Enums\v1;
+
+/**
+ * Enum Locale.
+ */
+enum Locale: string
+{
+    case en = 'en';
+    case fr = 'fr';
+    case de = 'de';
+    case it = 'it';
+    case nl = 'nl';
+    case es = 'es';
+    case pl = 'pl';
+}

--- a/src/Libs/Soa/v1/Yousign.php
+++ b/src/Libs/Soa/v1/Yousign.php
@@ -21,6 +21,7 @@ use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use RuntimeException;
 use Throwable;
 use function base64_decode;
@@ -169,10 +170,13 @@ class Yousign extends Soa
      * @param string $signatureRequestId
      * @param AddSignerRequest $addSignerRequest
      *
+     * @throws ValidationException
      * @return AddSignerResponse
      */
     public function addSigner(string $signatureRequestId, AddSignerRequest $addSignerRequest): AddSignerResponse
     {
+        $addSignerRequest->validate();
+
         $url = implode(
             self::URL_SEPARATOR,
             [

--- a/src/Structs/Soa/v1/AddSignerRequest.php
+++ b/src/Structs/Soa/v1/AddSignerRequest.php
@@ -3,9 +3,11 @@
 namespace Coverzen\Components\YousignClient\Structs\Soa\v1;
 
 use Coverzen\Components\YousignClient\Database\Factories\v1\AddSignerRequestFactory;
+use Coverzen\Components\YousignClient\Enums\v1\Locale;
 use Coverzen\Components\YousignClient\Enums\v1\SignatureAuthenticationMode;
 use Coverzen\Components\YousignClient\Enums\v1\SignatureLevel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Validation\Rules\Enum;
 
 /**
  * Class AddSignerRequest.
@@ -51,5 +53,20 @@ final class AddSignerRequest extends Request
     protected static function newFactory(): AddSignerRequestFactory
     {
         return AddSignerRequestFactory::new();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function validationRules(): array
+    {
+        return [
+            'info' => ['required', 'array'],
+            'info.first_name' => ['required', 'string'],
+            'info.last_name' => ['required', 'string'],
+            'info.email' => ['required', 'email'],
+            'info.phone_number' => ['nullable', 'string'],
+            'info.locale' => ['required', new Enum(Locale::class)],
+        ];
     }
 }

--- a/tests/Unit/Libs/Soa/v1/YousignTest.php
+++ b/tests/Unit/Libs/Soa/v1/YousignTest.php
@@ -28,6 +28,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -300,6 +301,26 @@ final class YousignTest extends TestCase
                                                       );
 
         (new Yousign())->uploadDocument(self::SIGNATURE_ID, $uploadDocumentRequest);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function it_validates_the_signer_before_sending_the_request(): void
+    {
+        /** @var AddSignerRequest $addSignerRequest */
+        $addSignerRequest = AddSignerRequest::factory()
+                                            ->make();
+
+        /** @phpstan-ignore assign.propertyType */
+        $addSignerRequest->info = Arr::except($addSignerRequest->info, ['locale']);
+
+        $this->expectException(ValidationException::class);
+
+        (new Yousign())->addSigner(self::SIGNATURE_ID, $addSignerRequest);
+
+        Http::assertNothingSent();
     }
 
     /**

--- a/tests/Unit/Structs/Soa/v1/AddSignerRequestTest.php
+++ b/tests/Unit/Structs/Soa/v1/AddSignerRequestTest.php
@@ -2,10 +2,15 @@
 
 namespace Coverzen\Components\YousignClient\Tests\Unit\Structs\Soa\v1;
 
+use Closure;
 use Coverzen\Components\YousignClient\Enums\v1\SignatureAuthenticationMode;
 use Coverzen\Components\YousignClient\Enums\v1\SignatureLevel;
 use Coverzen\Components\YousignClient\Exceptions\Structs\v1\StructSaveException;
 use Coverzen\Components\YousignClient\Structs\Soa\v1\AddSignerRequest;
+use Illuminate\Support\Arr;
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Class AddSignerRequestTest.
@@ -83,5 +88,48 @@ final class AddSignerRequestTest extends TestCase
         $this->expectException(StructSaveException::class);
 
         (new AddSignerRequest())->save();
+    }
+
+    #[Test]
+    public function it_passes_validation_with_a_complete_signer(): void
+    {
+        /** @var AddSignerRequest $addSignerRequest */
+        $addSignerRequest = AddSignerRequest::factory()
+                                            ->make();
+
+        $this->expectNotToPerformAssertions();
+
+        $addSignerRequest->validate();
+    }
+
+    /**
+     * @return array<string,array{Closure,string}>
+     */
+    public static function invalidInfoProvider(): array
+    {
+        return [
+            'missing first_name' => [static fn (array $info): array => Arr::except($info, ['first_name']), 'first name'],
+            'missing last_name' => [static fn (array $info): array => Arr::except($info, ['last_name']), 'last name'],
+            'missing email' => [static fn (array $info): array => Arr::except($info, ['email']), 'email'],
+            'missing locale' => [static fn (array $info): array => Arr::except($info, ['locale']), 'locale'],
+            'unsupported locale' => [static fn (array $info): array => [...$info, 'locale' => 'pt'], 'locale'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('invalidInfoProvider')]
+    public function it_fails_validation_when_the_signer_info_is_invalid(Closure $mutateInfo, string $messageFragment): void
+    {
+        /** @var AddSignerRequest $addSignerRequest */
+        $addSignerRequest = AddSignerRequest::factory()
+                                            ->make();
+
+        /** @phpstan-ignore assign.propertyType */
+        $addSignerRequest->info = $mutateInfo($addSignerRequest->info);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage($messageFragment);
+
+        $addSignerRequest->validate();
     }
 }


### PR DESCRIPTION
### What kind of change does this PR introduce?
Feature — fail-fast validation of the add-signer request.

### What is the new behavior?
When adding a signer, Yousign requires `info.locale` (enum: `en`, `fr`, `de`, `it`, `nl`, `es`, `pl`) as well as `first_name`, `last_name` and `email`. Until now the client sent the `AddSignerRequest` payload unvalidated, so a missing or invalid field only surfaced as a Yousign `400 parameters_not_valid` after the HTTP call.

This PR:
- adds a `Locale` enum (`src/Enums/v1/Locale.php`) covering the locales accepted by Yousign;
- adds validation rules on `AddSignerRequest` for the required `info` fields (`first_name`, `last_name`, `email`, `locale`), with `locale` constrained to the `Locale` enum;
- calls `validate()` in `Yousign::addSigner()`, so an invalid request throws a `ValidationException` before any HTTP request is sent.

Related to [CZDEV-2252](https://coverzen.atlassian.net/browse/CZDEV-2252)

### Does this PR introduce a breaking change?
No. Valid requests are unaffected; only previously-invalid requests (which Yousign would have rejected with a `400`) now fail fast with a `ValidationException`. `Yousign::addSigner()` now documents `@throws ValidationException`.

### Other information:
N/A
